### PR TITLE
use stars endpoint and fetch solar system when clicked

### DIFF
--- a/src/HostConfig.elm
+++ b/src/HostConfig.elm
@@ -11,7 +11,7 @@ type alias HostConfig =
 
 default : HostConfig
 default =
-    ( "https://radiofreewaba.net", [ "deepnight", "data", "solarsystems" ] )
+    ( "https://radiofreewaba.net", [ "deepnight", "data" ] )
 
 
 {-| A full Url.Parser that looks at the query string and returns it if found

--- a/src/Traveller.elm
+++ b/src/Traveller.elm
@@ -42,7 +42,7 @@ import Svg.Styled as Svg exposing (Svg)
 import Svg.Styled.Attributes as SvgAttrs exposing (points, viewBox)
 import Svg.Styled.Events as SvgEvents
 import Task
-import Traveller.HexAddress as HexAddress exposing (HexAddress)
+import Traveller.HexAddress as HexAddress exposing (HexAddress, hexLabel, toSectorKey)
 import Traveller.Parser as TravellerParser
 import Traveller.Point exposing (StellarPoint)
 import Traveller.Sector exposing (Sector, SectorDict, codecSector, sectorKey)
@@ -1501,8 +1501,20 @@ view model =
                     ]
                 , case model.selectedHex of
                     Just viewingAddress ->
+                        let
+                            key =
+                                toSectorKey viewingAddress
+
+                            hexDescription =
+                                case Dict.get key model.sectors of
+                                    Just sector ->
+                                        sector.name ++ " " ++ hexLabel viewingAddress
+
+                                    Nothing ->
+                                        "Hex Address: " ++ HexAddress.toKey viewingAddress
+                        in
                         column [ centerX, centerY, Font.size 10, Element.moveDown 20 ]
-                            [ text <| "Hex Address: " ++ HexAddress.toKey viewingAddress
+                            [ text <| hexDescription
                             ]
 
                     Nothing ->

--- a/src/Traveller/HexAddress.elm
+++ b/src/Traveller/HexAddress.elm
@@ -1,4 +1,4 @@
-module Traveller.HexAddress exposing (AfterChange, Delta, HexAddress, addVal, between, create, createFromSolarSystem, hexLabel, shiftAddressBy, toKey)
+module Traveller.HexAddress exposing (AfterChange, Delta, HexAddress, addVal, between, create, createFromSolarSystem, createFromStarSystem, hexLabel, shiftAddressBy, toKey)
 
 
 type alias HexAddress =
@@ -64,6 +64,11 @@ shiftAddressBy { deltaX, deltaY } { maxX, maxY } hexAddress =
 
 createFromSolarSystem : { a | sectorX : Int, sectorY : Int, x : Int, y : Int } -> HexAddress
 createFromSolarSystem { sectorX, sectorY, x, y } =
+    create { sectorX = sectorX, sectorY = sectorY, x = x, y = y }
+
+
+createFromStarSystem : { a | sectorX : Int, sectorY : Int, x : Int, y : Int } -> HexAddress
+createFromStarSystem { sectorX, sectorY, x, y } =
     create { sectorX = sectorX, sectorY = sectorY, x = x, y = y }
 
 

--- a/src/Traveller/HexAddress.elm
+++ b/src/Traveller/HexAddress.elm
@@ -1,4 +1,4 @@
-module Traveller.HexAddress exposing (AfterChange, Delta, HexAddress, addVal, between, create, createFromSolarSystem, createFromStarSystem, hexLabel, shiftAddressBy, toKey)
+module Traveller.HexAddress exposing (AfterChange, Delta, HexAddress, addVal, between, create, createFromSolarSystem, createFromStarSystem, hexLabel, shiftAddressBy, toKey, toSectorKey)
 
 
 type alias HexAddress =
@@ -90,6 +90,13 @@ toKey { sectorX, sectorY, x, y } =
         ++ String.fromInt x
         ++ "."
         ++ String.fromInt y
+
+
+toSectorKey : HexAddress -> String
+toSectorKey { sectorX, sectorY } =
+    String.fromInt sectorX
+        ++ "."
+        ++ String.fromInt sectorY
 
 
 {-| Returns a list of hex addresses between two hex addresses, inclusive.

--- a/src/Traveller/Sector.elm
+++ b/src/Traveller/Sector.elm
@@ -1,0 +1,33 @@
+module Traveller.Sector exposing (Sector, SectorDict, codecSector, sectorKey)
+
+import Codec exposing (Codec)
+import Dict
+
+
+type alias Sector =
+    { x : Int
+    , y : Int
+    , name : String
+    , abbreviation : String
+    }
+
+
+sectorKey : Sector -> String
+sectorKey sector =
+    String.fromInt sector.x
+        ++ "."
+        ++ String.fromInt sector.y
+
+
+codecSector : Codec Sector
+codecSector =
+    Codec.object Sector
+        |> Codec.field "x" .x Codec.int
+        |> Codec.field "y" .y Codec.int
+        |> Codec.field "name" .name Codec.string
+        |> Codec.field "name" .abbreviation Codec.string
+        |> Codec.buildObject
+
+
+type alias SectorDict =
+    Dict.Dict String Sector

--- a/src/Traveller/SolarSystemStars.elm
+++ b/src/Traveller/SolarSystemStars.elm
@@ -1,0 +1,133 @@
+module Traveller.SolarSystemStars exposing (StarSystem, StarType, StarTypeData, getStarTypeData, starSystemCodec, starTypeCodec)
+
+import Codec exposing (Codec, lazy, list, object)
+import Traveller.HexAddress as HexAddress exposing (HexAddress)
+import Traveller.StarColour exposing (StarColour, codecStarColour)
+
+
+type alias StarTypeData =
+    { au : Float
+    , subtype : Int
+    , companion : Maybe StarType
+    , stellarType : String
+    , stellarClass : String
+    , colour : Maybe StarColour
+    , diameter : Maybe Float
+    }
+
+
+type StarType
+    = StarTypeWrap StarTypeData
+
+
+getStarTypeData : StarType -> StarTypeData
+getStarTypeData (StarTypeWrap starTypeData) =
+    starTypeData
+
+
+starTypeCodec : Codec StarType
+starTypeCodec =
+    object StarTypeData
+        |> Codec.field "au" .au Codec.float
+        |> Codec.field "subtype" .subtype Codec.int
+        |> Codec.field "companion" .companion (Codec.nullable <| Codec.lazy (\_ -> starTypeCodec))
+        |> Codec.field "stellarType" .stellarType Codec.string
+        |> Codec.field "stellarClass" .stellarClass Codec.string
+        |> Codec.field "colour" .colour (Codec.nullable codecStarColour)
+        |> Codec.field "diameter" .diameter (Codec.nullable Codec.float)
+        |> Codec.buildObject
+        |> Codec.map StarTypeWrap (\(StarTypeWrap data) -> data)
+
+
+type alias StarSystem =
+    { address : HexAddress
+    , sectorName : String
+    , name : String
+    , scanPoints : Int
+    , surveyIndex : Int
+    , gasGiantCount : Int
+    , terrestrialPlanetCount : Int
+    , planetoidBeltCount : Int
+    , allegiance : Maybe String
+    , stars : List StarType
+    }
+
+
+type alias RawStarSystem =
+    { name : String
+    , x : Int
+    , y : Int
+    , sectorX : Int
+    , sectorY : Int
+    , sectorName : String
+    , scanPoints : Int
+    , surveyIndex : Int
+    , gasGiantCount : Int
+    , terrestrialPlanetCount : Int
+    , planetoidBeltCount : Int
+    , allegiance : Maybe String
+    , stars : List StarType
+    }
+
+
+starSystemCodec : Codec.Codec StarSystem
+starSystemCodec =
+    rawStarSystemCodec
+        |> Codec.andThen rawStarSystemToStarSystem starSystemToRawStarSystem
+
+
+rawStarSystemToStarSystem : RawStarSystem -> Codec.Codec StarSystem
+rawStarSystemToStarSystem rawStarSystem =
+    Codec.succeed
+        { address = HexAddress.createFromStarSystem rawStarSystem
+        , sectorName = rawStarSystem.sectorName
+        , name = rawStarSystem.name
+        , gasGiantCount = rawStarSystem.gasGiantCount
+        , planetoidBeltCount = rawStarSystem.planetoidBeltCount
+        , terrestrialPlanetCount = rawStarSystem.terrestrialPlanetCount
+        , surveyIndex = rawStarSystem.surveyIndex
+        , scanPoints = rawStarSystem.scanPoints
+        , allegiance = rawStarSystem.allegiance
+        , stars = rawStarSystem.stars
+        }
+
+
+starSystemToRawStarSystem : StarSystem -> RawStarSystem
+starSystemToRawStarSystem starSystem =
+    let
+        { sectorX, sectorY, x, y } =
+            starSystem.address
+    in
+    { x = x
+    , y = y
+    , sectorX = sectorX
+    , sectorY = sectorY
+    , gasGiantCount = starSystem.gasGiantCount
+    , planetoidBeltCount = starSystem.planetoidBeltCount
+    , terrestrialPlanetCount = starSystem.terrestrialPlanetCount
+    , surveyIndex = starSystem.surveyIndex
+    , sectorName = starSystem.sectorName
+    , name = starSystem.name
+    , allegiance = starSystem.allegiance
+    , stars = starSystem.stars
+    , scanPoints = starSystem.scanPoints
+    }
+
+
+rawStarSystemCodec : Codec RawStarSystem
+rawStarSystemCodec =
+    object RawStarSystem
+        |> Codec.field "name" .name Codec.string
+        |> Codec.field "x" .x Codec.int
+        |> Codec.field "y" .y Codec.int
+        |> Codec.field "sector_x" .sectorX Codec.int
+        |> Codec.field "sector_y" .sectorY Codec.int
+        |> Codec.field "sector_name" .sectorName Codec.string
+        |> Codec.field "scan_points" .scanPoints Codec.int
+        |> Codec.field "survey_index" .surveyIndex Codec.int
+        |> Codec.field "gas_giant_count" .gasGiantCount Codec.int
+        |> Codec.field "terrestrial_planet_count" .terrestrialPlanetCount Codec.int
+        |> Codec.field "planetoid_belt_count" .planetoidBeltCount Codec.int
+        |> Codec.field "allegiance" .allegiance (Codec.nullable Codec.string)
+        |> Codec.field "stars" .stars (list starTypeCodec)
+        |> Codec.buildObject

--- a/src/Traveller/Star.elm
+++ b/src/Traveller/Star.elm
@@ -2,7 +2,7 @@ module Traveller.Star exposing (Star(..), StarData, codecStar, getStarData, samp
 
 import Codec exposing (Codec)
 import Traveller.Point as Point exposing (StellarPoint)
-import Traveller.StarColour exposing (StarColour)
+import Traveller.StarColour exposing (StarColour, codecStarColour)
 import Traveller.StellarObject exposing (StellarObject, codecStellarObject)
 
 

--- a/src/Traveller/Star.elm
+++ b/src/Traveller/Star.elm
@@ -1,11 +1,8 @@
-module Traveller.Star exposing (Star(..), StarColour, StarData, codecStar, getStarData, sampleSystemText, starColourRGB)
+module Traveller.Star exposing (Star(..), StarData, codecStar, getStarData, sampleSystemText)
 
 import Codec exposing (Codec)
-import Json.Decode as JsDecode
-import Json.Encode as JsEncode
-import Parser exposing ((|.), (|=), Parser)
-import Parser.Extras as Parser
-import Traveller.Point exposing (StellarPoint, codecStellarPoint)
+import Traveller.Point as Point exposing (StellarPoint)
+import Traveller.StarColour exposing (StarColour)
 import Traveller.StellarObject exposing (StellarObject, codecStellarObject)
 
 
@@ -59,69 +56,6 @@ sampleSystemText =
   "jump": 3.0392399646555845
 }
 """
-
-
-type StarColour
-    = Blue
-    | BlueWhite
-    | White
-    | YellowWhite
-    | Yellow
-    | LightOrange
-    | OrangeRed
-    | Red
-    | Brown
-    | DeepDimRed
-
-
-codecStarColour : Codec StarColour
-codecStarColour =
-    Codec.enum Codec.string
-        [ ( "Blue", Blue )
-        , ( "Blue White", BlueWhite )
-        , ( "White", White )
-        , ( "Yellow White", YellowWhite )
-        , ( "Yellow", Yellow )
-        , ( "Light Orange", LightOrange )
-        , ( "Orange Red", OrangeRed )
-        , ( "Red", Red )
-        , ( "Brown", Brown )
-        , ( "Deep Dim Red", DeepDimRed )
-        ]
-
-
-starColourRGB : StarColour -> String
-starColourRGB colour =
-    case colour of
-        Blue ->
-            "#000077"
-
-        BlueWhite ->
-            "#87cefa"
-
-        White ->
-            "#FFFFFF"
-
-        YellowWhite ->
-            "#ffffe0"
-
-        Yellow ->
-            "#ffff00"
-
-        LightOrange ->
-            "#ffbf00"
-
-        OrangeRed ->
-            "#ff4500"
-
-        Red ->
-            "#ff0000"
-
-        Brown ->
-            "#f4a460"
-
-        DeepDimRed ->
-            "#800000"
 
 
 type Star
@@ -190,7 +124,7 @@ buildStarData orbitPosition_ inclination_ eccentricity_ effectiveHZCODeviation_ 
 codecStar : Codec Star
 codecStar =
     Codec.object buildStarData
-        |> Codec.field "orbitPosition" .orbitPosition codecStellarPoint
+        |> Codec.field "orbitPosition" .orbitPosition Point.codec
         |> Codec.field "inclination" .inclination Codec.int
         |> Codec.field "eccentricity" .eccentricity Codec.float
         |> Codec.field "effectiveHZCODeviation" .effectiveHZCODeviation (Codec.nullable Codec.float)

--- a/src/Traveller/StarColour.elm
+++ b/src/Traveller/StarColour.elm
@@ -1,0 +1,69 @@
+module Traveller.StarColour exposing (StarColour, codecStarColour, starColourRGB)
+
+import Codec exposing (Codec)
+
+
+type StarColour
+    = Blue
+    | BlueWhite
+    | White
+    | YellowWhite
+    | Yellow
+    | LightOrange
+    | OrangeRed
+    | Red
+    | Brown
+    | DeepDimRed
+
+
+codecStarColour : Codec StarColour
+codecStarColour =
+    Codec.enum Codec.string
+        [ ( "Blue", Blue )
+        , ( "Blue White", BlueWhite )
+        , ( "White", White )
+        , ( "Yellow White", YellowWhite )
+        , ( "Yellow", Yellow )
+        , ( "Light Orange", LightOrange )
+        , ( "Orange Red", OrangeRed )
+        , ( "Red", Red )
+        , ( "Brown", Brown )
+        , ( "Deep Dim Red", DeepDimRed )
+        ]
+
+
+starColourRGB : Maybe StarColour -> String
+starColourRGB colour =
+    case colour of
+        Just Blue ->
+            "#000077"
+
+        Just BlueWhite ->
+            "#87cefa"
+
+        Just White ->
+            "#FFFFFF"
+
+        Just YellowWhite ->
+            "#ffffe0"
+
+        Just Yellow ->
+            "#ffff00"
+
+        Just LightOrange ->
+            "#ffbf00"
+
+        Just OrangeRed ->
+            "#ff4500"
+
+        Just Red ->
+            "#ff0000"
+
+        Just Brown ->
+            "#f4a460"
+
+        Just DeepDimRed ->
+            "#800000"
+
+        Nothing ->
+            "#000000"

--- a/src/Traveller/StellarObject.elm
+++ b/src/Traveller/StellarObject.elm
@@ -1,84 +1,10 @@
-module Traveller.StellarObject exposing (GasGiantData, InnerStarData, PlanetoidBeltData, PlanetoidData, StarData(..), StellarObject(..), TerrestrialData, codecStarData, codecStellarObject, getInnerStarData, getSafeJumpTime, getStellarOrbit, starColourRGB)
+module Traveller.StellarObject exposing (GasGiantData, InnerStarData, PlanetoidBeltData, PlanetoidData, StarData(..), StellarObject(..), TerrestrialData, codecStarData, codecStellarObject, getInnerStarData, getSafeJumpTime, getStellarOrbit)
 
 import Codec exposing (Codec)
 import Json.Decode as JsDecode
-import Json.Decode.Pipeline as Decode
-import Json.Encode as JsEncode
-import Parser exposing ((|.), (|=), Parser)
-import Parser.Extras as Parser
-import Random.Char as Codec
-import Traveller.Atmosphere as Atmosphere exposing (StellarAtmosphere)
-import Traveller.Hydrographics as Hydrographics exposing (StellarHydrographics)
 import Traveller.Moon as Moon exposing (Moon)
-import Traveller.Orbit as Orbit exposing (StellarOrbit)
 import Traveller.Point as Point exposing (StellarPoint)
-import Traveller.Population as Population exposing (StellarPopulation)
-
-
-type StarColour
-    = Blue
-    | BlueWhite
-    | White
-    | YellowWhite
-    | Yellow
-    | LightOrange
-    | OrangeRed
-    | Red
-    | Brown
-    | DeepDimRed
-
-
-codecStarColour : Codec StarColour
-codecStarColour =
-    Codec.enum Codec.string
-        [ ( "Blue", Blue )
-        , ( "Blue White", BlueWhite )
-        , ( "White", White )
-        , ( "Yellow White", YellowWhite )
-        , ( "Yellow", Yellow )
-        , ( "Light Orange", LightOrange )
-        , ( "Orange Red", OrangeRed )
-        , ( "Red", Red )
-        , ( "Brown", Brown )
-        , ( "Deep Dim Red", DeepDimRed )
-        ]
-
-
-starColourRGB : Maybe StarColour -> String
-starColourRGB colour =
-    case colour of
-        Just Blue ->
-            "#000077"
-
-        Just BlueWhite ->
-            "#87cefa"
-
-        Just White ->
-            "#FFFFFF"
-
-        Just YellowWhite ->
-            "#ffffe0"
-
-        Just Yellow ->
-            "#ffff00"
-
-        Just LightOrange ->
-            "#ffbf00"
-
-        Just OrangeRed ->
-            "#ff4500"
-
-        Just Red ->
-            "#ff0000"
-
-        Just Brown ->
-            "#f4a460"
-
-        Just DeepDimRed ->
-            "#800000"
-
-        Nothing ->
-            "#000000"
+import Traveller.StarColour exposing (StarColour, codecStarColour)
 
 
 type alias TerrestrialData =

--- a/todo.md
+++ b/todo.md
@@ -6,6 +6,8 @@
 * [X] click to drag map
 * [X] use stars instead of solarsystems
 ** [ ] fetch solar system when clicked
+* [X] load list of sectors
+** [ ] display sector name in sidebar
 * [ ] fix clipping of map to viewport boundaries
 * [ ] table'd sidebar (recursively render the columns, account for SVG's width, since its HTML and elm-ui isn't aware of that size)
 * [X] support multi-sector viewing

--- a/todo.md
+++ b/todo.md
@@ -7,7 +7,7 @@
 * [X] use stars instead of solarsystems
 ** [ ] fetch solar system when clicked
 * [X] load list of sectors
-** [ ] display sector name in sidebar
+** [X] display sector name in sidebar
 * [ ] fix clipping of map to viewport boundaries
 * [ ] table'd sidebar (recursively render the columns, account for SVG's width, since its HTML and elm-ui isn't aware of that size)
 * [X] support multi-sector viewing

--- a/todo.md
+++ b/todo.md
@@ -4,6 +4,8 @@
 * [X] Account for offsets when dragging
 * [X] Display sector coordinates in sidebar
 * [X] click to drag map
+* [ ] use stars instead of solarsystems
+** [ ] fetch solar system when clicked
 * [ ] fix clipping of map to viewport boundaries
 * [ ] table'd sidebar (recursively render the columns, account for SVG's width, since its HTML and elm-ui isn't aware of that size)
 * [X] support multi-sector viewing

--- a/todo.md
+++ b/todo.md
@@ -1,6 +1,9 @@
 # To Do
 
 ## MVP
+* [ ] Correct display of hex numbers across sectors
+* [ ] Ensure call to get star sectors includes all hexes on the map
+* [ ] Resolve issue with "Loading..." being displayed and never removed when scrolling
 * [X] Account for offsets when dragging
 * [X] Display sector coordinates in sidebar
 * [X] click to drag map

--- a/todo.md
+++ b/todo.md
@@ -4,7 +4,7 @@
 * [X] Account for offsets when dragging
 * [X] Display sector coordinates in sidebar
 * [X] click to drag map
-* [ ] use stars instead of solarsystems
+* [X] use stars instead of solarsystems
 ** [ ] fetch solar system when clicked
 * [ ] fix clipping of map to viewport boundaries
 * [ ] table'd sidebar (recursively render the columns, account for SVG's width, since its HTML and elm-ui isn't aware of that size)


### PR DESCRIPTION
Stars is a lot smaller and parses a lot quicker. So that is used instead of fetching all the data. stars typically returns in under 20ms. Fetching a single solar system takes around 12ms. 

Not sure I coded everything correctly. The left panel looks funny but I have not got around to figuring out why.